### PR TITLE
update to the new integration endpoint

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Specto",
-            url: "https://users.specto.dev/binary-releases/xcframework/0.1.0.zip",
+            url: "https://users.specto.dev/binary-releases/ios/sdk/release/xcframework/0.1.0",
             checksum: "dc43185e4f401603999ce23352350708e1ba6f330043af7d8a5c4855319604a0"),
     ]
 )


### PR DESCRIPTION
- moving off of the hardcoded version we're currently maintaining for backwards compat
- removed the .zip extension as that request 500'd, whereas the committed version worked when I tested in Safari